### PR TITLE
Fix EZP-21365: eZ Password Expiry support for users with main location outside "Users"

### DIFF
--- a/classes/ezpaex.php
+++ b/classes/ezpaex.php
@@ -375,7 +375,7 @@ class eZPaEx extends eZPersistentObject
             eZDebug::writeDebug( 'Going to update subtree starting at node ' . $mainNodeID . '.', __METHOD__ );
 
             // Fetch the full subtree array to update
-            $fullSubtree = eZContentObjectTreeNode::subTreeByNodeID( array( "MainNodeOnly" => true,
+            $fullSubtree = eZContentObjectTreeNode::subTreeByNodeID( array( "MainNodeOnly" => false,
                                                                             "AsObject" => false ),
                                                                     $mainNodeID );
 
@@ -394,7 +394,7 @@ class eZPaEx extends eZPersistentObject
                 }
                 else
                 {
-                    eZDebug::writeDebug( 'Skipping object ' . $add_paex_to_update->attribute( 'contentobject_id' ) , __METHOD__ );
+                    eZDebug::writeDebug( 'Skipping object ' . $add_paex_to_update['contentobject_id'] , __METHOD__ );
                 }
             }
         }


### PR DESCRIPTION
As in topic. We have a users with second (and main) location under 'Content structure'. Without this fix ezmbpaex_updatechildren cronjob doesn't update Password Expiration attributes.

And $add_paex_to_update from line 397 seems to be an array, not an object.

cheers,
Bogdan
