### PR TITLE
FIX Last Visit date not updated after user logged in

### DIFF
--- a/modules/userpaex/password.php
+++ b/modules/userpaex/password.php
@@ -110,6 +110,7 @@ if ( $http->hasPostVariable( "OKButton" ) && $user)
                         $oldPassword = '';
 
                         eZUser::setCurrentlyLoggedInUser( $user, $UserID );
+                        eZUser::updateLastVisit( $UserID );
 
                         if ( $http->hasPostVariable( "RedirectOnChange" ) )
                         {

--- a/modules/userpaex/password.php
+++ b/modules/userpaex/password.php
@@ -110,7 +110,7 @@ if ( $http->hasPostVariable( "OKButton" ) && $user)
                         $oldPassword = '';
 
                         eZUser::setCurrentlyLoggedInUser( $user, $UserID );
-                        eZUser::updateLastVisit( $UserID );
+                        eZUser::updateLastVisit( $UserID, true );
 
                         if ( $http->hasPostVariable( "RedirectOnChange" ) )
                         {


### PR DESCRIPTION
We have developed custom cronjob to disable user who not logged in after some time after creating (by checking `ezuservisit` table).
But, Last Visit date not updated if user logged in providing old and new passwords in this module (userpaex/password).
I believe it should be updated in the same way as in standard "user/login" module.